### PR TITLE
Fix alignment

### DIFF
--- a/components/SocialList.tsx
+++ b/components/SocialList.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.ol<Pick<SocialListProps, "iconSize" | "gap" | "innerPaddi
   align-items: center;
   max-width: 110rem;
   width: 100%;
-  margin: 0 auto;
+  margin: 0;
   padding: 0;
   gap: ${({ gap }) => gap ? `${gap}rem` : '7rem'};
   list-style-type: none;


### PR DESCRIPTION
Fixes the alignment of the footer social icons, on larger resolution screens (zoom out in the browser to try replicate) (reported by @cmagan and @harisang 

Now:
<img width="376" alt="Screen Shot 2022-01-11 at 20 18 07" src="https://user-images.githubusercontent.com/31534717/149007148-3ef317bf-99a5-44ab-b494-fa11a68d1f87.png">
)

After:
<img width="296" alt="Screen Shot 2022-01-11 at 20 18 35" src="https://user-images.githubusercontent.com/31534717/149007218-746d9d08-fdb2-48d9-b6db-14adfdd1553a.png">

