### PR TITLE
Add a JOBS page with remote data fetching.

### DIFF
--- a/components/Layout/Content.tsx
+++ b/components/Layout/Content.tsx
@@ -6,6 +6,7 @@ import { mainMenu, footerMenu } from '../../const/menu'
 import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
 import { Color, Font, Media } from 'const/styles/variables'
+import { Content } from 'const/styles/pages/content'
 
 export type LayoutProps = PropsWithChildren<{
   siteConfigData?: any // needs fix
@@ -19,39 +20,6 @@ const Wrapper = styled.div`
   padding: 0;
   box-sizing: border-box;
   width: 100%;
-`
-
-const Content = styled.main`
-  margin: 0 auto;
-  padding: 18rem 0 0;
-  box-sizing: border-box;
-  width: 100%;
-  max-width: 84rem;
-  display: flex;
-  flex-flow: column wrap;
-  min-height: 80rem;
-
-  h1 {
-    font-size: 8rem;
-    line-height: 1.2;
-    margin: 0 0 6rem;
-  }
-
-  h2 {
-    font-size: 3rem;
-    line-height: 1.2;
-    margin: 0 0 2.4rem;
-  }
-
-  p {
-    margin: 0 0 1.6rem;
-    font-size: ${Font.sizeDefault};
-    color: ${Color.grey};
-  }
-
-  section {
-    margin: 0 0 6rem;
-  }
 `
 
 export default function Layout({ children }: LayoutProps) {

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -5,7 +5,6 @@ import { siteConfig } from 'const/meta'
 import { mainMenu, footerMenu } from '../../const/menu'
 import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
-import { Media } from 'const/styles/variables'
 
 export type LayoutProps = PropsWithChildren<{
   siteConfigData?: any // needs fix

--- a/const/menu.ts
+++ b/const/menu.ts
@@ -2,11 +2,12 @@ import { siteConfig } from 'const/meta'
 const {url, social} = siteConfig
 
 export const mainMenu = [
-  { id: 0, title: 'Documentation', url: url.docs, target: "_blank", rel: "noopener nofollow" },
+  { id: 0, title: 'Docs', url: url.docs, target: "_blank", rel: "noopener nofollow" },
   { id: 1, title: 'Developers', url: '/#developers'},
   // { id: 1, title: 'About', url: '/#about' },
   { id: 2, title: 'Community', url: social.discord.url, target: "_blank", rel: "noopener nofollow" },
   { id: 3, title: 'Analytics', url: url.analytics, target: "_blank", rel: "noopener nofollow" },
+  { id: 4, title: 'Jobs', url: '/jobs' },
 ]
 
 export const footerMenu = [
@@ -16,6 +17,7 @@ export const footerMenu = [
       { title: 'About CowSwap', url: 'https://cowswap.exchange/#/about', target: "_blank" },
       { title: 'CowSwap FAQ', url: 'https://cowswap.exchange/#/faq', target: "_blank" },
       { title: 'Analytics', url: url.analytics, target: "_blank" },
+      { title: 'Jobs', url: '/jobs' },
     
       // { title: 'Sitemap', url: '/' },
     ]

--- a/const/meta.ts
+++ b/const/meta.ts
@@ -11,7 +11,11 @@ export const siteConfig = {
     api: API_BASE_URL + "/mainnet",
     apiDocs: API_BASE_URL + "/docs",
     analytics: "https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2",
-    explorer: "https://explorer.cow.fi"
+    explorer: "https://explorer.cow.fi",
+  },
+  greenhouse: {
+    api: "https://boards-api.greenhouse.io/v1/boards/gnosis/jobs?content=true",
+    deptID: 4065870002
   },
   social: {
     twitter: { label: 'Twitter', account: '@MEVprotection', url: 'https://twitter.com/mevprotection' },

--- a/const/styles/pages/content.ts
+++ b/const/styles/pages/content.ts
@@ -39,6 +39,8 @@ export const Title = styled.h1`
   font-size: 6rem;
   line-height: 1.2;
   margin: 0 0 4rem;
+  text-align: center;
+  word-break: break-word;
 
   ${Media.mobile} {
     font-size: 4rem;
@@ -50,6 +52,7 @@ export const SubTitle = styled.h2`
   line-height: 1.5;
   font-weight: ${Font.weightLight};
   opacity: 0.75;
+  text-align: center;
 
   ${Media.mobile} {
     font-size: 2rem;

--- a/const/styles/pages/content.ts
+++ b/const/styles/pages/content.ts
@@ -4,17 +4,16 @@ import { Color, Font, Media } from 'const/styles/variables'
 
 export const Content = styled.main`
   margin: 0 auto;
-  padding: 8rem 0;
+  padding: 8rem 3.2rem;
   box-sizing: border-box;
   width: 100%;
-  max-width: 84rem;
+  max-width: 90rem;
   display: flex;
   flex-flow: column wrap;
   min-height: 80rem;
 
   ${Media.mobile} {
     height: auto;
-    padding: 8rem 3.2rem;
     max-width: 100%;
     min-height: initial;
   }

--- a/const/styles/pages/content.ts
+++ b/const/styles/pages/content.ts
@@ -1,0 +1,131 @@
+import styled from 'styled-components';
+import { transparentize } from 'polished'
+import { Color, Font, Media } from 'const/styles/variables'
+
+export const Content = styled.main`
+  margin: 0 auto;
+  padding: 8rem 0;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 84rem;
+  display: flex;
+  flex-flow: column wrap;
+  min-height: 80rem;
+
+  ${Media.mobile} {
+    height: auto;
+    padding: 8rem 3.2rem;
+    max-width: 100%;
+    min-height: initial;
+  }
+
+  p {
+    margin: 0 0 1.6rem;
+    font-size: ${Font.sizeDefault};
+    color: ${Color.grey};
+    line-height: 1.4;
+  }
+`
+
+export const Section = styled.section`
+  display: flex;
+  flex-flow: row wrap;
+  width: 100%;
+  margin: 0 0 6rem;
+  position: relative;
+  z-index: 1;
+ `
+
+export const Title = styled.h1`
+  font-size: 6rem;
+  line-height: 1.2;
+  margin: 0 0 4rem;
+
+  ${Media.mobile} {
+    font-size: 4rem;
+  }
+ `
+
+export const SubTitle = styled.h2`
+  font-size: 2.4rem;
+  line-height: 1.5;
+  font-weight: ${Font.weightLight};
+  opacity: 0.75;
+
+  ${Media.mobile} {
+    font-size: 2rem;
+  }
+`
+
+export const TitleSmall = styled.h3`
+  font-size: 2.4rem;
+  line-height: 1.2;
+  margin: 0 0 2.4rem;
+ `
+
+ export const LinkContainer = styled.a`
+    display: flex;
+    flex-flow: column wrap;
+    box-sizing: border-box;
+    padding: 2.4rem 6.2rem 2.4rem 2.4rem;
+    margin: 0 0 1.6rem;
+    border-radius: 1.6rem;
+    align-items: flex-start;
+    justify-content: center;
+    font-size: 1.8rem;
+    background: ${transparentize(0.9, Color.white)};
+    border: 0.1rem solid ${transparentize(0.9, Color.white)};
+    color: ${Color.white};
+    transition: color 0.2s ease-in-out, background 0.2s ease-in-out, border 0.2s ease-in-out;
+    font-weight: ${Font.weightLight};
+    text-decoration: none;
+    position: relative;
+    max-width: 100%;
+
+      &:last-of-type {
+        margin: 0 0 4.2rem;
+      }
+
+      &:link, &:visited {
+        color: inherit;
+      }
+
+      &:hover {
+        background: ${transparentize(0.9, Color.orange)};
+        border: 0.1rem solid ${Color.orange};
+        color: ${Color.orange};
+
+        > svg { transform: translateX(0.6rem) }
+        > svg > path { fill: ${Color.orange}} }
+      }
+
+      > b {
+        line-height: 1.2;
+      }
+
+      > i {
+        font-size: 1.6rem;
+        font-style: normal;
+        margin: 0.8rem 0 0;
+      }
+
+      > svg {
+        display: block;
+        position: absolute;
+        right: 2.4rem;
+        top: 0;
+        bottom: 0;
+        margin: auto;
+        width: 2.4rem;
+        height: 2.4rem;
+        transform: translateX(0);
+        transition: transform 0.2s ease-in-out;
+          
+        > path { fill: ${transparentize(0.7, Color.white)}; }
+      }
+ `
+
+ export const LoadingText = styled.p`
+  font-size: 1.6rem;
+  color: ${Color.white}
+ `

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-device-detect": "^2.1.2",
     "react-dom": "17.0.2",
     "react-ga": "^2.5.7",
+    "react-inlinesvg": "^2.3.0",
     "react-intersection-observer": "^8.33.1",
     "react-syntax-highlighter": "^15.4.5",
     "remark": "^14.0.2",

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -54,9 +54,8 @@ export default function Jobs({ jobsData }) {
           <SVG src="images/icons/arrowRight.svg" />
         </LinkContainer>
       )}
-      {/* {!isLoading && jobs.length < 1 && <p>There are currently no open positions.</p>} */}
 
-      <p>No open positions or can&apos;t find the position you&apos;re looking for? <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>
+      {!isLoading && <p>{jobs.length < 1 && 'Currently there are no open positions. Convinced you can contribute to Cow Protocol?'}{jobs.length > 0 && "Can't find the position you're looking for?"} <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>}
 
     </Content>
   )

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -35,6 +35,9 @@ export default function Jobs({ jobsData }) {
         setJobs(data)
         setLoading(false)
       })
+      .catch((error) => {
+        console.log(error)
+      })
   }, [])
 
   return (
@@ -66,5 +69,10 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: { jobsData },
+    
+    // Next.js will attempt to re-generate the page:
+    // - When a request comes in
+    // - At most once every 3600 seconds (1 hour)
+    revalidate: 3600, // In seconds
   }
 }

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -24,21 +24,6 @@ async function getJobs() {
 
 export default function Jobs({ jobsData }) {
   const discordURL = siteConfig.social.discord.url
-  const [jobs, setJobs] = useState(jobsData)
-  const [isLoading, setLoading] = useState(false)
-
-  // Fetch the latest jobs to possibly override static rendered (getStaticProps) SSR jobs
-  useEffect(() => {
-    setLoading(true)
-    getJobs()
-      .then((data) => {
-        setJobs(data)
-        setLoading(false)
-      })
-      .catch((error) => {
-        console.log(error)
-      })
-  }, [])
 
   return (
     <Content>
@@ -49,8 +34,7 @@ export default function Jobs({ jobsData }) {
 
       <TitleSmall>Who we are looking for:</TitleSmall>
 
-      {isLoading && <LoadingText>Loading jobs...</LoadingText>}
-      {!isLoading && jobs.length > 0 && jobs.map(({ title, absolute_url, location, internal_job_id }) =>
+      {jobsData.length > 0 && jobsData.map(({ title, absolute_url, location, internal_job_id }) =>
         <LinkContainer key={internal_job_id} href={absolute_url} target="_blank" rel="noopener nofollow noreferrer">
           <b>{title}</b>
           <i>{location.name}</i>
@@ -58,7 +42,7 @@ export default function Jobs({ jobsData }) {
         </LinkContainer>
       )}
 
-      {!isLoading && <p>{jobs.length < 1 && 'Currently there are no open positions. Convinced you can contribute to Cow Protocol?'}{jobs.length > 0 && "Can't find the position you're looking for?"} <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>}
+      <p>{jobsData.length < 1 && 'Currently there are no open positions. Convinced you can contribute to Cow Protocol?'}{jobsData.length > 0 && "Can't find the position you're looking for?"} <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>
 
     </Content>
   )

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -51,7 +51,7 @@ export default function Jobs({ jobsData }) {
         <LinkContainer key={internal_job_id} href={absolute_url} target="_blank" rel="noopener nofollow noreferrer">
           <b>{title}</b>
           <i>{location.name}</i>
-          <SVG src="images/icons/arrowRight.svg" />
+          <SVG src="images/icons/arrowRight.svg" cacheRequests={true} />
         </LinkContainer>
       )}
 

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -1,0 +1,71 @@
+// import Link from 'next/link'
+import { useState, useEffect } from 'react'
+import { GetStaticProps } from 'next'
+import { siteConfig } from '@/const/meta'
+import Content from 'components/Layout/Content'
+import { Section, Title, SubTitle, TitleSmall, LinkContainer, LoadingText } from 'const/styles/pages/content'
+import { ExternalLink } from '@/const/styles/global'
+import SVG from 'react-inlinesvg'
+
+async function getJobs() {
+  const { api, deptID } = siteConfig.greenhouse
+  const getJobs = await fetch(api)
+  const { jobs } = await getJobs.json()
+  const jobsData = []
+  await jobs.map((job) => {
+    const dept = job.departments[0]
+    if (dept) {
+      dept.id === deptID ? jobsData.push(job) : null
+    }
+  })
+
+  return jobsData
+}
+
+export default function Jobs({ jobsData }) {
+  const discordURL = siteConfig.social.discord.url
+  const [jobs, setJobs] = useState(jobsData)
+  const [isLoading, setLoading] = useState(false)
+
+  // Fetch the latest jobs to possibly override static rendered (getStaticProps) SSR jobs
+  useEffect(() => {
+    setLoading(true)
+    getJobs()
+      .then((data) => {
+        setJobs(data)
+        setLoading(false)
+      })
+  }, [])
+
+  return (
+    <Content>
+      <Section>
+        <Title>Want to build the future of decentralized trading?</Title>
+        <SubTitle>We are an ambitious, fast growing and international team working at the forefront of DeFi. We believe that we can make markets both more efficient and fair, by building the ultimate batch auction settlement layer across EVM compatible blockchains.</SubTitle>
+      </Section>
+
+      <TitleSmall>Who we are looking for:</TitleSmall>
+
+      {isLoading && <LoadingText>Loading jobs...</LoadingText>}
+      {!isLoading && jobs.length > 0 && jobs.map(({ title, absolute_url, location, internal_job_id }) =>
+        <LinkContainer key={internal_job_id} href={absolute_url} target="_blank" rel="noopener nofollow noreferrer">
+          <b>{title}</b>
+          <i>{location.name}</i>
+          <SVG src="images/icons/arrowRight.svg" />
+        </LinkContainer>
+      )}
+      {/* {!isLoading && jobs.length < 1 && <p>There are currently no open positions.</p>} */}
+
+      <p>No open positions or can&apos;t find the position you&apos;re looking for? <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>
+
+    </Content>
+  )
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const jobsData = await getJobs()
+
+  return {
+    props: { jobsData },
+  }
+}

--- a/public/images/icons/arrowRight.svg
+++ b/public/images/icons/arrowRight.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 19 16">
+  <path fill="#000" fill-rule="evenodd" d="M14.071 9 9.5 13.571l1.5 1.5L18.071 8 11 .929l-1.5 1.5L14.071 7H0v2h14.071Z" clip-rule="evenodd"/>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2036,6 +2036,11 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+exenv@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -3990,10 +3995,23 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-from-dom@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-from-dom/-/react-from-dom-0.6.1.tgz#6740f5a3d79e0c354703e5c096b8fdfe0db71b0f"
+  integrity sha512-7aAZx7LhRnmR51W5XtmTBYHGFl2n1AdEk1uoXLuzHa1OoGXrxOW/iwLcudvgp6BGX/l4Yh1rtMrIzvhlvbVddg==
+
 react-ga@^2.5.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
   integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
+
+react-inlinesvg@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-inlinesvg/-/react-inlinesvg-2.3.0.tgz#62283c0ce7e9d11d8190ec3e89589102288830fd"
+  integrity sha512-fEGOdDf4k4bcveArbEpj01pJcH8pOCKLxmSj2POFdGvEk5YK0NZVnH6BXpW/PzACHPRsuh1YKAhNZyFnD28oxg==
+  dependencies:
+    exenv "^1.2.2"
+    react-from-dom "^0.6.0"
 
 react-intersection-observer@^8.33.1:
   version "8.33.1"


### PR DESCRIPTION
This adds a /jobs/ page to cow.fi
- Fetches the latest jobs from Greenhouse and filters out the right department by ID (CowSwap)
- Fetching happens on build for static rendering.
- Separately on client side, there will be also a new data fetch, to pull the latest positions.
- This achieves the effect of having a jobs page with indexable (job) content for SEO purposes, by having the static fallback. At the same time makes sure to pull the actual latest jobs client-side in case the static render is not up-to-date. If that fails -> fallback is in place.
- Adds `jobs` to the main menu.
- Renamed `documentation` to => `docs` to keep the header menu compact.

<img width="1617" alt="Screen Shot 2022-03-08 at 12 09 18" src="https://user-images.githubusercontent.com/31534717/157235898-81ad5fd2-4e52-4bfd-a357-efc381526e75.png">

# Todo
- For future iterations I'd plan to add a bit more styling/branding/images to the content pages (including the jobs page). For now not prioritizing this yet.
- In this PR I start working towards having a more general purpose 'Content' stylesheet/components. This is to be further enhanced.
- The Greenhouse API endpoint doesn't return jobs data, grouped by inner department type (instead `department` is used to distinguish between `CowSwap`, `Gnosis` etc). In the future if Cow Protocol would have it's own Greenhouse instance, the actual `department` key name could be used to group jobs by actual departments (Front-end, Back-end, Accounting, HR, etc.).