### PR TITLE
Set use of variable font file.

### DIFF
--- a/const/styles/global.ts
+++ b/const/styles/global.ts
@@ -3,10 +3,11 @@ import styled, { createGlobalStyle } from 'styled-components'
 import { Color, Font, Media } from 'const/styles/variables'
 
 const GlobalStyles = createGlobalStyle`
-  html { font-family: "Inter", "system-ui"; }
+
+  html, body { font-family: "Inter", "system-ui"; }
 
   @supports (font-variation-settings: normal) {
-    html { font-family: "Inter var", "system-ui"; }
+    html, body { font-family: "Inter var", "system-ui"; }
   }
 
   html, body {  

--- a/const/styles/variables.ts
+++ b/const/styles/variables.ts
@@ -14,7 +14,7 @@ export const Color = {
 }
 
 export const Font = {
-  default: "'Inter', 'Helvetica Neue', Helvetica, sans-serif",
+  default: "'Inter var', 'Helvetica Neue', Helvetica, sans-serif",
   arial: "Arial, Helvetica, sans-serif",
   sizeDefault: '1.6rem',
   weightLight: 300,


### PR DESCRIPTION
This update makes sure we're using the variable font variant of `inter-ui`. A variable font should result in lower file sizes for client side font assets fetching.